### PR TITLE
fix: Correct portrait prices, contact info, and navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
         </div>
         <nav class="nav">
             <a href="#" class="nav-link">Home</a>
-            <a href="#" class="nav-link">Portfolio</a>
-            <a href="#" class="nav-link">Services</a>
+            <a href="https://adobe.ly/3P9IOGN" class="nav-link" target="_blank">Portfolio</a>
+            <a href="#package-builder-section" class="nav-link">Services</a>
             <a href="#" class="nav-link">About</a>
-            <a href="#" class="nav-link">Contact</a>
+            <a href="#footer" class="nav-link">Contact</a>
         </nav>
     </header>
 
@@ -276,7 +276,7 @@
         </div>
     </section>
 
-    <footer class="footer">
+    <footer class="footer" id="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
@@ -286,26 +286,27 @@
                     <div class="footer-column">
                         <h3>Navigation</h3>
                         <a href="#">Home</a>
-                        <a href="#">Portfolio</a>
-                        <a href="#">Services</a>
+                        <a href="https://adobe.ly/3P9IOGN" target="_blank">Portfolio</a>
+                        <a href="#package-builder-section">Services</a>
                         <a href="#">About</a>
-                        <a href="#">Contact</a>
+                        <a href="#footer">Contact</a>
                     </div>
                     <div class="footer-column">
                         <h3>Services</h3>
-                        <a href="#">Wedding Photography</a>
-                        <a href="#">Event Videography</a>
-                        <a href="#">Portrait Sessions</a>
-                        <a href="#">Commercial Production</a>
+                        <a href="https://youtube.com/playlist?list=PLaBGc1dfIKtSF7ybUANh37c_6wV055FfQ" target="_blank">Wedding Photography</a>
+                        <a href="https://youtu.be/JMCvPcut658" target="_blank">Event Videography</a>
+                        <a href="https://adobe.ly/3P9IOGN" target="_blank">Portrait Sessions</a>
+                        <a href="https://youtu.be/JMCvPcut658" target="_blank">Commercial Production</a>
                     </div>
                     <div class="footer-column">
                         <h3>Contact</h3>
-                        <p>Email: info@getmonie.com</p>
-                        <p>Phone: (123) 456-7890</p>
+                        <p>Email: getmonieproductions@gmail.com</p>
+                        <p>Phone: 337-356-2331</p>
+                        <p><a href="https://drive.google.com/file/d/1a3pqkJ_Do3fK2fCQLCQgpwPHPfHwA6Wu/view?usp=sharing" target="_blank">Virtual Business Card</a></p>
                         <div class="social-icons">
-                            <a href="#" class="social-icon">FB</a>
-                            <a href="#" class="social-icon">IG</a>
-                            <a href="#" class="social-icon">TW</a>
+                            <a href="https://www.facebook.com/GetMonieProductions/" class="social-icon" target="_blank">FB</a>
+                            <a href="https://www.instagram.com/qmoniep/" class="social-icon" target="_blank">IG</a>
+                            <a href="https://youtube.com/playlist?list=PLaBGc1dfIKtSF7ybUANh37c_6wV055FfQ" class="social-icon" target="_blank">YT</a>
                         </div>
                     </div>
                 </div>

--- a/package-builder.js
+++ b/package-builder.js
@@ -78,15 +78,15 @@ const packageData = {
   ],
   "portrait-photography": [
     {
-      id: "a_1hr", name: "A (1HR PKG)", price: 249, retainer: 75, description: "1 hour portrait session.",
+      id: "a_1hr", name: "A (1HR PKG)", price: 150, retainer: 75, description: "1 hour portrait session.",
       features: ["Up to 1 Hr coverage", "1 Location", "1 Outfit Change", "(Minimum of) 5 Detailed Photos", "20 candids with access to cloud folder", "Edits can take 2 wks or more.", "Additional photos may be purchased: $10/standard edits, $20/high quality edits.", "Retainer/Total includes cost of extra EQ."]
     },
     {
-      id: "b_2hr", name: "B (2HR PKG)", price: 339, retainer: 125, description: "2 hour portrait session.",
+      id: "b_2hr", name: "B (2HR PKG)", price: 250, retainer: 125, description: "2 hour portrait session.",
       features: ["Up to 2 Hr coverage", "2 Locations", "2 Outfit Changes", "(Minimum of) 10 Detailed Photos", "all candids with access to cloud folder", "Edits can take 2 wks or more.", "Additional photos may be purchased: $10/standard edits, $20/high quality edits.", "Retainer/Total includes cost of extra EQ."]
     },
     {
-      id: "c_3hr", name: "C (3HR PKG)", price: 399, retainer: 175, description: "3 hour portrait session with highlight reel.",
+      id: "c_3hr", name: "C (3HR PKG)", price: 325, retainer: 175, description: "3 hour portrait session with highlight reel.",
       features: ["Up to 3 Hr coverage", "3 Locations", "3 Outfit Changes", "(Minimum of) 15 Detailed Photos", "all candids with access to cloud folder", "highlight reel", "Edits can take 2 wks or more.", "Additional photos may be purchased: $10/standard edits, $20/high quality edits.", "Retainer/Total includes cost of extra EQ."]
     }
   ],


### PR DESCRIPTION
This commit addresses issues identified after the comprehensive pricing overhaul:

1.  **Corrected Portrait Session Photography Prices:**
    - Updated prices in `package-builder.js` for "Portrait Session" -> "Photography" packages: - Package A (1HR PKG): $150 (Retainer $75) - Package B (2HR PKG): $250 (Retainer $125) - Package C (3HR PKG): $325 (Retainer $175)

2.  **Updated Contact Information in Footer (`index.html`):**
    - Phone number changed to `337-356-2331`.
    - Display email address changed to `getmonieproductions@gmail.com`.

3.  **Updated Header and Footer Navigation Links (`index.html`):**
    - Header "Home" to `#`, "Portfolio" to Adobe link, "Services" to `#package-builder-section`, "About" to `#`, "Contact" to `#footer`.
    - Footer "Navigation" and "Services" column links updated to your provided URLs (YouTube playlist for Wedding Photo, Showreel for Event/Production Video, Adobe Portfolio for Portrait Sessions).
    - Added `id="footer"` to the main `<footer>` tag.
    - Added "Virtual Business Card" link to the footer.
    - Social media icons updated: Facebook and Instagram links corrected, Twitter icon removed, YouTube icon and link added. External links set to open in a new tab.