### PR TITLE
fix: Resolve game start issue and add touch controls

### DIFF
--- a/monie-drop.css
+++ b/monie-drop.css
@@ -120,3 +120,54 @@ body {
         width: 90vw;
     }
 }
+
+/* Touch Controls Styles */
+.touch-controls-container {
+    display: none; /* Hidden by default, shown via media query for touch devices */
+    justify-content: space-around;
+    align-items: center;
+    width: 100%;
+    max-width: 400px; /* Adjust as needed */
+    margin: 2rem auto 1rem; /* Spacing from game area and bottom */
+    padding: 0.5rem;
+    background-color: rgba(255, 255, 255, 0.1); /* Subtle background */
+    border-radius: 8px;
+}
+
+.touch-control-button {
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    border-radius: 50%; /* Circular buttons */
+    width: 60px;       /* Size of buttons */
+    height: 60px;
+    font-size: 1.8rem; /* Size of arrow icons */
+    font-weight: bold;
+    cursor: pointer;
+    transition: var(--transition);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}
+
+.touch-control-button:hover,
+.touch-control-button:active {
+    background-color: #c4a030; /* Darker gold on hover/active */
+    transform: translateY(-2px);
+}
+
+/* Show touch controls on smaller screens (typical for touch devices) */
+/* This is a common proxy for touch capability, but not perfect. */
+/* Ideally, JS would detect touch support and show controls. */
+@media (max-width: 768px) { /* Or a more specific breakpoint for touch UIs */
+    .touch-controls-container {
+        display: flex;
+    }
+    .game-info .controls p { /* Hide keyboard instructions on small screens */
+        display: none;
+    }
+    .game-info .controls p.touch-instruction { /* Add a class for touch instruction if needed */
+        display: block;
+    }
+}

--- a/monie-drop.html
+++ b/monie-drop.html
@@ -34,14 +34,26 @@
                 </div>
                 <div class="controls">
                     <h2>Controls</h2>
-                    <p>Left/Right Arrows: Move</p>
-                    <p>Up Arrow: Rotate</p>
-                    <p>Down Arrow: Speed Up</p>
-                    <p>P: Pause</p>
+                    <!-- Keyboard instructions will be hidden by CSS on smaller screens -->
+                    <p class="keyboard-instruction">Left/Right Arrows: Move</p>
+                    <p class="keyboard-instruction">Up Arrow: Rotate</p>
+                    <p class="keyboard-instruction">Down Arrow: Speed Up</p>
+                    <p class="keyboard-instruction">P: Pause</p>
+                    <!-- Touch instructions - will be shown by default or if keyboard hidden -->
+                    <p class="touch-instruction">Use on-screen buttons to control.</p>
+                    <p class="touch-instruction">Tap P (top of screen or via menu if added) to Pause.</p>
+                    <!-- Note: Pause button for touch needs to be considered, for now 'P' key is mentioned -->
                 </div>
             </div>
         </div>
         <button id="startGameBtn" class="cta-button">Start Game</button>
+
+        <div class="touch-controls-container">
+            <button id="touchLeftBtn" class="touch-control-button" aria-label="Move Left">&#x2190;</button>
+            <button id="touchRotateBtn" class="touch-control-button" aria-label="Rotate">&#x21BB;</button>
+            <button id="touchDownBtn" class="touch-control-button" aria-label="Move Down">&#x2193;</button>
+            <button id="touchRightBtn" class="touch-control-button" aria-label="Move Right">&#x2192;</button>
+        </div>
     </main>
 
     <footer class="footer" id="footer">


### PR DESCRIPTION
This commit addresses several issues and adds new features:

- Fixes a bug where the game would not start correctly after clicking the 'Start Game' button. Ensured proper canvas clearing and reset of animation flags on game start.
- Implements touch controls with on-screen buttons for left, right, rotate, and down actions, making the game playable on mobile devices.
- Updates Monie-Mino shapes based on detailed descriptions:
    - Introduces 'Classic_GM' (6x4 piece).
    - Introduces 'G_Only' (3x4 G-shape).
    - Introduces 'Heavy_3D' (chunky C-shape).
- Implements the 'Candy Drop' special piece:
    - Uses 'Classic_GM' shape, appears with multi-colored blocks.
    - Awards a point bonus and triggers a candy particle shower upon landing.
- Enhances Bomb and Rocket effects with a 'Monie Flash' animation, including a screen flash and sparkle particles before blocks are cleared.
- Ensures particles from non-line-clearing effects (like Candy Drop) are drawn in the main game loop.

Further testing, especially regarding the playability of the large 'Classic_GM' piece, is recommended.